### PR TITLE
Fixes type signature for .select effects with parametric selectors

### DIFF
--- a/effects.d.ts
+++ b/effects.d.ts
@@ -35,7 +35,7 @@ interface EffectApi<R> {
     };
     race(effects: { [key: string]: E.Effect }): R;
     race(effects: E.Effect[]): R;
-    select<S>(selector?: (state: S) => any, ...args: any[]): R;
+    select<S>(selector?: (state: S, ...args: any[]) => any, ...args: any[]): R;
     call<T>(fn: [T, Function], ...args: any[]): R;
     call<T, K extends keyof T>(fn: [T, K], ...args: any[]): R;
     call(fn: Function, ...args: any[]): R;


### PR DESCRIPTION
Pull in typing fix from gwyneth-bassett fork